### PR TITLE
Adding support for Django 1.10 (Model._meta function updated)

### DIFF
--- a/pagemore/templatetags/pagemore.py
+++ b/pagemore/templatetags/pagemore.py
@@ -58,7 +58,7 @@ class FilteringPaginator(BasePaginator):
         objects = self.objects
         if after_val is not None:
             field_type = self.objects.model \
-                ._meta.get_field_by_name(self.order_field)[0]
+            ._meta.get_field(self.order_field)
             if isinstance(field_type, DateTimeField):
                 after_val = timezone.make_aware(
                     datetime.utcfromtimestamp(int(after_val)),


### PR DESCRIPTION
Hi, i have tested django-pagemore on a project i have on Django 1.10, i did a little adjust on the Model._meta API call on the paginate method of the FilteringPaginator based on this: https://docs.djangoproject.com/en/1.10/ref/models/meta/#migrating-from-the-old-api

Everything is working fine on Django 1.10 after this, i have tested both strategies with all params.